### PR TITLE
Fix [fieldSelection]: properly handle nullable fields

### DIFF
--- a/cli/src/runtime/typeSelection.ts
+++ b/cli/src/runtime/typeSelection.ts
@@ -46,10 +46,9 @@ type HandleObject<SRC extends Anify<DST>, DST> = SRC extends Nil
           {
               // using keyof SRC to maintain ?: relations of SRC type
               [Key in keyof SRC]: Key extends keyof DST
-                  ? FieldsSelection<
-                        SRC[Key],
-                        NonNullable<DST[Key]>
-                    >
+                  ? SRC[Key] extends infer NON_NULL_SRC | null
+                  ? FieldsSelection<NON_NULL_SRC, NonNullable<DST[Key]>> | null
+                  : FieldsSelection<SRC[Key], NonNullable<DST[Key]>>
                   : SRC[Key]
           },
           Exclude<keyof DST, FieldsToRemove>


### PR DESCRIPTION
When fields are nullable, we end up trying to use FieldSelection with a first type param that extends null, and it causes a problem that makes anything beyond that field to be inferred as any.

Check the isolated issue on following Codesandbox:

> Go to the end of the file and check the types of withIssue and fixed

https://codesandbox.io/p/sandbox/solitary-morning-jwkt3k?file=%2Fusage.ts%3A33%2C63